### PR TITLE
fix: returning values instead of pointers from cronet

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -61,11 +61,8 @@ jobs:
         name: Install dependencies
         run: dart pub get
       - id: get_binaries
-        name: Download Cronet Binaries
+        name: Download/Build Cronet Binaries
         run: dart run cronet:setup
-      - id: build_wrapper
-        name: Build Cronet Wrapper Dylib
-        run: dart run cronet:setup build
       - name: Run VM tests
         run: dart test --platform vm
         if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -64,7 +64,7 @@ jobs:
         name: Download Cronet Binaries
         run: dart run cronet:setup
       - id: build_wrapper
-        name: Download Cronet Wrapper Dylib
+        name: Build Cronet Wrapper Dylib
         run: dart run cronet:setup build
       - name: Run VM tests
         run: dart test --platform vm

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -63,6 +63,9 @@ jobs:
       - id: get_binaries
         name: Download Cronet Binaries
         run: dart run cronet:setup
+      - id: build_wrapper
+        name: Download Cronet Wrapper Dylib
+        run: dart run cronet:setup build
       - name: Run VM tests
         run: dart test --platform vm
         if: always() && steps.install.outcome == 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.1+1
+
+* `HttpClientResponse`'s `followRedirects` and `maxRedirects` are now modifiable.
+* Fixed: utf8 decoding of newLocation in case of redirects.
+
 ## 0.0.1
 
 * HttpClient with QUIC, HTTP2, brotli support.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a [GSoC 2021 project](https://summerofcode.withgoogle.com/projects/#4757
 
 Currently, 64 bit Linux and Windows systems are supported.
 
+## Requirements
+
+1. Dart SDK 2.12.0 or above.
+2. CMake 3.15 or above. (If on windows, Visual Studio 2019 with C++ tools)
+3. C++ compiler. (g++/clang/msvc)
+
 ## Usage
 
 1. Add package as a dependency in your `pubspec.yaml`.

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -37,9 +37,6 @@ void placeBinaries(String platform, String fileName) {
   logger.stdout('Done! Cleaning up...');
 
   File(fileName).deleteSync();
-  logger.stdout(
-      '${ansi.green}Done! Cronet support for $platform is now available!'
-      '${ansi.none}');
 }
 
 /// Download `cronet` library from Github Releases.
@@ -63,8 +60,11 @@ Future<void> downloadCronetBinaries(String platform) async {
     } catch (error) {
       Exception("Can't download. Check your network connection!");
     }
-
     placeBinaries(platform, fileName);
+    buildWrapper();
+    logger.stdout(
+        '${ansi.green}Done! Cronet support for $platform is now available!'
+        '${ansi.none}');
   } else {
     logger.stdout('${ansi.yellow}Cronet $platform is already available.'
         ' No need to download.${ansi.none}');

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -80,8 +80,12 @@ void buildWrapper() {
   Directory.current = Directory(wrapperPath);
   logger.stdout('Building Wrapper...');
   try {
-    final result = Process.runSync(
-        'cmake', ['CMakeLists.txt', '-B', 'out/${Platform.operatingSystem}']);
+    final result = Process.runSync('cmake', [
+      'CMakeLists.txt',
+      '-B',
+      'out/${Platform.operatingSystem}',
+      '-DCMAKE_BUILD_TYPE=Release'
+    ]);
     print(result.stdout);
     print(result.stderr);
   } catch (error) {
@@ -95,8 +99,8 @@ void buildWrapper() {
     }
     return;
   }
-  var result =
-      Process.runSync('cmake', ['--build', 'out/${Platform.operatingSystem}']);
+  var result = Process.runSync('cmake',
+      ['--build', 'out/${Platform.operatingSystem}', '--config', 'Release']);
   print(result.stdout);
   print(result.stderr);
   if (result.exitCode != 0) return;
@@ -105,7 +109,7 @@ void buildWrapper() {
   Directory(moveLocation).createSync(recursive: true);
   final buildOutputPath = Platform.isLinux
       ? '$wrapperPath/out/${Platform.operatingSystem}/${getWrapperName()}'
-      : '$wrapperPath\\out\\${Platform.operatingSystem}\\Debug\\${getWrapperName()}';
+      : '$wrapperPath\\out\\${Platform.operatingSystem}\\Release\\${getWrapperName()}';
   File(buildOutputPath).copySync('$moveLocation/${getWrapperName()}');
   logger.stdout(
       '${ansi.green}Wrapper moved to $moveLocation. Success!${ansi.none}');

--- a/example_dart/bin/example_dart.dart
+++ b/example_dart/bin/example_dart.dart
@@ -10,7 +10,7 @@ void main(List<String> args) {
   for (var i = 0; i < 3; i++) {
     // Demo - with concurrent requests
     client
-        .getUrl(Uri.parse('https://postman-echo.com/headers'))
+        .getUrl(Uri.parse('https://example.com'))
         .then((HttpClientRequest request) {
       if (i == 2) {
         client.close(); // We will shut down the client after 3 connections.
@@ -21,6 +21,8 @@ void main(List<String> args) {
         print(contents);
       }, onDone: () {
         print('cronet implemenation took: ${stopwatch.elapsedMilliseconds} ms');
+      }, onError: (Object e) {
+        print(e);
       });
     });
   }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -9,6 +9,7 @@ const tag = 'binaries-v0.0.1';
 const cronetBinaryUrl =
     'https://github.com/google/cronet.dart/releases/download/$tag/';
 const cronetVersion = "86.0.4240.198";
+const wrapperVersion = "1.0";
 
 const binaryStorageDir = '.dart_tool/cronet/';
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -9,7 +9,7 @@ const tag = 'binaries-v0.0.1';
 const cronetBinaryUrl =
     'https://github.com/google/cronet.dart/releases/download/$tag/';
 const cronetVersion = "86.0.4240.198";
-const wrapperVersion = "1.0";
+const wrapperVersion = "1";
 
 const binaryStorageDir = '.dart_tool/cronet/';
 

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -14,7 +14,7 @@ import 'wrapper/generated_bindings.dart';
 
 Wrapper loadAndInitWrapper() {
   final wrapper = Wrapper(loadWrapper());
-  if (wrapperVersion != wrapper.versionString().cast<Utf8>().toDartString()) {
+  if (wrapperVersion != wrapper.VersionString().cast<Utf8>().toDartString()) {
     final logger = Logger.standard();
     final ansi = Ansi(Ansi.terminalSupportsAnsi);
     logger.stderr('${ansi.red}Wrapper is outdated.${ansi.none}');

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -4,12 +4,24 @@
 
 import 'dart:ffi';
 
+import 'package:cli_util/cli_logging.dart';
+import 'package:ffi/ffi.dart';
+
+import 'constants.dart';
 import 'dylib_handler.dart';
 import 'third_party/cronet/generated_bindings.dart';
 import 'wrapper/generated_bindings.dart';
 
 Wrapper loadAndInitWrapper() {
   final wrapper = Wrapper(loadWrapper());
+  if (wrapperVersion != wrapper.versionString().cast<Utf8>().toDartString()) {
+    final logger = Logger.standard();
+    final ansi = Ansi(Ansi.terminalSupportsAnsi);
+    logger.stderr('${ansi.red}Wrapper is outdated.${ansi.none}');
+    logger.stdout('Update wrapper by running: '
+        '${ansi.yellow}dart run cronet:setup${ansi.none}');
+    throw Error();
+  }
   // Initialize Dart Native API dynamically.
   wrapper.InitDartApiDL(NativeApi.initializeApiDLData);
   // Registers few cronet functions that are required by the wrapper.

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -20,7 +20,8 @@ Wrapper loadAndInitWrapper() {
       cronet.addresses.Cronet_Buffer_Create.cast(),
       cronet.addresses.Cronet_Buffer_InitWithAlloc.cast(),
       cronet.addresses.Cronet_UrlResponseInfo_http_status_code_get.cast(),
-      cronet.addresses.Cronet_Error_message_get.cast());
+      cronet.addresses.Cronet_Error_message_get.cast(),
+      cronet.addresses.Cronet_UrlResponseInfo_http_status_text_get.cast());
   // Registers few cronet functions that are required by the executor
   // run from the wrapper for executing network requests.
   // Casting because of https://github.com/dart-lang/ffigen/issues/22

--- a/lib/src/globals.dart
+++ b/lib/src/globals.dart
@@ -18,7 +18,9 @@ Wrapper loadAndInitWrapper() {
       cronet.addresses.Cronet_Engine_Shutdown.cast(),
       cronet.addresses.Cronet_Engine_Destroy.cast(),
       cronet.addresses.Cronet_Buffer_Create.cast(),
-      cronet.addresses.Cronet_Buffer_InitWithAlloc.cast());
+      cronet.addresses.Cronet_Buffer_InitWithAlloc.cast(),
+      cronet.addresses.Cronet_UrlResponseInfo_http_status_code_get.cast(),
+      cronet.addresses.Cronet_Error_message_get.cast());
   // Registers few cronet functions that are required by the executor
   // run from the wrapper for executing network requests.
   // Casting because of https://github.com/dart-lang/ffigen/issues/22

--- a/lib/src/http_callback_handler.dart
+++ b/lib/src/http_callback_handler.dart
@@ -64,12 +64,12 @@ class CallbackHandler {
   }
 
   /// Checks status of an URL response.
-  int statusChecker(
-      int respCode, int lBound, int uBound, void Function() callback) {
+  int statusChecker(int respCode, Pointer<Utf8> status, int lBound, int uBound,
+      void Function() callback) {
     if (!(respCode >= lBound && respCode <= uBound)) {
       // If NOT in range.
       callback();
-      final exception = HttpException('$respCode');
+      final exception = HttpException(status.toDartString());
       _controller.addError(exception);
       _controller.close();
     }
@@ -100,8 +100,8 @@ class CallbackHandler {
                 '${newUrlPtr.toDartString()}');
             malloc.free(newUrlPtr);
             // If NOT a 3XX status code, throw Exception.
-            statusChecker(
-                args[1], 300, 399, () => cleanUpRequest(reqPtr, cleanUpClient));
+            statusChecker(args[1], Pointer.fromAddress(args[2]), 300, 399,
+                () => cleanUpRequest(reqPtr, cleanUpClient));
             if (followRedirects && maxRedirects > 0) {
               final res = cronet.Cronet_UrlRequest_FollowRedirect(reqPtr);
               if (res != Cronet_RESULT.Cronet_RESULT_SUCCESS) {
@@ -119,8 +119,8 @@ class CallbackHandler {
         case 'OnResponseStarted':
           {
             // If NOT a 1XX or 2XX status code, throw Exception.
-            statusChecker(
-                args[0], 100, 299, () => cleanUpRequest(reqPtr, cleanUpClient));
+            statusChecker(args[0], Pointer.fromAddress(args[2]), 100, 299,
+                () => cleanUpRequest(reqPtr, cleanUpClient));
             log('Response started');
             final res = cronet.Cronet_UrlRequest_Read(
                 reqPtr, Pointer.fromAddress(args[1]).cast<Cronet_Buffer>());
@@ -142,8 +142,8 @@ class CallbackHandler {
 
             log('Recieved: $bytesRead');
             // If NOT a 1XX or 2XX status code, throw Exception.
-            statusChecker(
-                args[1], 100, 299, () => cleanUpRequest(reqPtr, cleanUpClient));
+            statusChecker(args[1], Pointer.fromAddress(args[4]), 100, 299,
+                () => cleanUpRequest(reqPtr, cleanUpClient));
             final data = cronet.Cronet_Buffer_GetData(buffer)
                 .cast<Uint8>()
                 .asTypedList(bytesRead);

--- a/lib/src/http_callback_handler.dart
+++ b/lib/src/http_callback_handler.dart
@@ -100,8 +100,10 @@ class CallbackHandler {
       switch (reqMessage.method) {
         case 'OnRedirectReceived':
           {
+            final newUrlPtr = Pointer.fromAddress(args[0]).cast<Utf8>();
             log('New Location: '
-                '${Pointer.fromAddress(args[0]).cast<Utf8>().toDartString()}');
+                '${newUrlPtr.toDartString()}');
+            malloc.free(newUrlPtr);
             // If NOT a 3XX status code, throw Exception.
             statusChecker(
                 Pointer.fromAddress(args[1]).cast<Cronet_UrlResponseInfo>(),

--- a/lib/src/http_callback_handler.dart
+++ b/lib/src/http_callback_handler.dart
@@ -69,8 +69,13 @@ class CallbackHandler {
     if (!(respCode >= lBound && respCode <= uBound)) {
       // If NOT in range.
       callback();
-      final exception = HttpException(status.toDartString());
-      _controller.addError(exception);
+      if (status == nullptr) {
+        _controller.addError(HttpException('$respCode'));
+      } else {
+        _controller.addError(HttpException(status.toDartString()));
+        malloc.free(status);
+      }
+
       _controller.close();
     }
     return respCode;

--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -52,10 +52,12 @@ abstract class HttpClientRequest implements io.IOSink {
 
   /// Follow the redirects.
   bool get followRedirects;
+  set followRedirects(bool follow);
 
   /// Maximum numbers of redirects to follow.
   /// Have no effect if [followRedirects] is set to false.
   int get maxRedirects;
+  set maxRedirects(int redirects);
 
   /// The uri of the request.
   Uri get uri;
@@ -149,6 +151,7 @@ class HttpClientRequestImpl implements HttpClientRequest {
   /// Follow the redirects.
   @override
   bool get followRedirects => _callbackHandler.followRedirects;
+  @override
   set followRedirects(bool follow) {
     _callbackHandler.followRedirects = follow;
   }
@@ -157,6 +160,7 @@ class HttpClientRequestImpl implements HttpClientRequest {
   /// Have no effect if [followRedirects] is set to false.
   @override
   int get maxRedirects => _callbackHandler.maxRedirects;
+  @override
   set maxRedirects(int redirects) {
     _callbackHandler.maxRedirects = redirects;
   }

--- a/lib/src/third_party/cronet/ffigen.yaml
+++ b/lib/src/third_party/cronet/ffigen.yaml
@@ -19,6 +19,7 @@ functions:
       - 'Cronet_Buffer_InitWithAlloc'
       - 'Cronet_UrlResponseInfo_http_status_code_get'
       - 'Cronet_Error_message_get'
+      - 'Cronet_UrlResponseInfo_http_status_text_get'
       # For executor.
       - 'Cronet_Executor_CreateWith'
       - 'Cronet_Executor_SetClientContext'

--- a/lib/src/third_party/cronet/ffigen.yaml
+++ b/lib/src/third_party/cronet/ffigen.yaml
@@ -17,6 +17,8 @@ functions:
       - 'Cronet_Engine_Destroy'
       - 'Cronet_Buffer_Create'
       - 'Cronet_Buffer_InitWithAlloc'
+      - 'Cronet_UrlResponseInfo_http_status_code_get'
+      - 'Cronet_Error_message_get'
       # For executor.
       - 'Cronet_Executor_CreateWith'
       - 'Cronet_Executor_SetClientContext'

--- a/lib/src/third_party/cronet/generated_bindings.dart
+++ b/lib/src/third_party/cronet/generated_bindings.dart
@@ -3023,7 +3023,8 @@ class Cronet {
   }
 
   late final _Cronet_UrlResponseInfo_http_status_text_get_ptr = _lookup<
-          ffi.NativeFunction<_c_Cronet_UrlResponseInfo_http_status_text_get>>(
+          ffi.NativeFunction<
+              Native_Cronet_UrlResponseInfo_http_status_text_get>>(
       'Cronet_UrlResponseInfo_http_status_text_get');
   late final _dart_Cronet_UrlResponseInfo_http_status_text_get
       _Cronet_UrlResponseInfo_http_status_text_get =
@@ -4686,6 +4687,11 @@ class _SymbolAddresses {
               Native_Cronet_UrlResponseInfo_http_status_code_get>>
       get Cronet_UrlResponseInfo_http_status_code_get =>
           _library._Cronet_UrlResponseInfo_http_status_code_get_ptr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              Native_Cronet_UrlResponseInfo_http_status_text_get>>
+      get Cronet_UrlResponseInfo_http_status_text_get =>
+          _library._Cronet_UrlResponseInfo_http_status_text_get_ptr;
 }
 
 class Cronet_Buffer extends ffi.Opaque {}
@@ -6773,8 +6779,8 @@ typedef _dart_Cronet_UrlResponseInfo_http_status_code_get = int Function(
   ffi.Pointer<Cronet_UrlResponseInfo> self,
 );
 
-typedef _c_Cronet_UrlResponseInfo_http_status_text_get = ffi.Pointer<ffi.Int8>
-    Function(
+typedef Native_Cronet_UrlResponseInfo_http_status_text_get
+    = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<Cronet_UrlResponseInfo> self,
 );
 

--- a/lib/src/third_party/cronet/generated_bindings.dart
+++ b/lib/src/third_party/cronet/generated_bindings.dart
@@ -1691,7 +1691,7 @@ class Cronet {
   }
 
   late final _Cronet_Error_message_get_ptr =
-      _lookup<ffi.NativeFunction<_c_Cronet_Error_message_get>>(
+      _lookup<ffi.NativeFunction<Native_Cronet_Error_message_get>>(
           'Cronet_Error_message_get');
   late final _dart_Cronet_Error_message_get _Cronet_Error_message_get =
       _Cronet_Error_message_get_ptr.asFunction<
@@ -3006,7 +3006,8 @@ class Cronet {
   }
 
   late final _Cronet_UrlResponseInfo_http_status_code_get_ptr = _lookup<
-          ffi.NativeFunction<_c_Cronet_UrlResponseInfo_http_status_code_get>>(
+          ffi.NativeFunction<
+              Native_Cronet_UrlResponseInfo_http_status_code_get>>(
       'Cronet_UrlResponseInfo_http_status_code_get');
   late final _dart_Cronet_UrlResponseInfo_http_status_code_get
       _Cronet_UrlResponseInfo_http_status_code_get =
@@ -4678,6 +4679,13 @@ class _SymbolAddresses {
       get Cronet_Engine_Destroy => _library._Cronet_Engine_Destroy_ptr;
   ffi.Pointer<ffi.NativeFunction<Native_Cronet_Engine_Shutdown>>
       get Cronet_Engine_Shutdown => _library._Cronet_Engine_Shutdown_ptr;
+  ffi.Pointer<ffi.NativeFunction<Native_Cronet_Error_message_get>>
+      get Cronet_Error_message_get => _library._Cronet_Error_message_get_ptr;
+  ffi.Pointer<
+          ffi.NativeFunction<
+              Native_Cronet_UrlResponseInfo_http_status_code_get>>
+      get Cronet_UrlResponseInfo_http_status_code_get =>
+          _library._Cronet_UrlResponseInfo_http_status_code_get_ptr;
 }
 
 class Cronet_Buffer extends ffi.Opaque {}
@@ -6048,7 +6056,7 @@ typedef _dart_Cronet_Error_error_code_get = int Function(
   ffi.Pointer<Cronet_Error> self,
 );
 
-typedef _c_Cronet_Error_message_get = ffi.Pointer<ffi.Int8> Function(
+typedef Native_Cronet_Error_message_get = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<Cronet_Error> self,
 );
 
@@ -6757,7 +6765,7 @@ typedef _dart_Cronet_UrlResponseInfo_url_chain_clear = void Function(
   ffi.Pointer<Cronet_UrlResponseInfo> self,
 );
 
-typedef _c_Cronet_UrlResponseInfo_http_status_code_get = ffi.Int32 Function(
+typedef Native_Cronet_UrlResponseInfo_http_status_code_get = ffi.Int32 Function(
   ffi.Pointer<Cronet_UrlResponseInfo> self,
 );
 

--- a/lib/src/wrapper/generated_bindings.dart
+++ b/lib/src/wrapper/generated_bindings.dart
@@ -44,12 +44,17 @@ class Wrapper {
     ffi.Pointer<ffi.NativeFunction<_typedefC_2>> Cronet_Engine_Destroy,
     ffi.Pointer<ffi.NativeFunction<_typedefC_3>> Cronet_Buffer_Create,
     ffi.Pointer<ffi.NativeFunction<_typedefC_4>> Cronet_Buffer_InitWithAlloc,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
+        Cronet_UrlResponseInfo_http_status_code_get,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
   ) {
     return _InitCronetApi(
       Cronet_Engine_Shutdown,
       Cronet_Engine_Destroy,
       Cronet_Buffer_Create,
       Cronet_Buffer_InitWithAlloc,
+      Cronet_UrlResponseInfo_http_status_code_get,
+      Cronet_Error_message_get,
     );
   }
 
@@ -60,14 +65,14 @@ class Wrapper {
 
   /// Forward declaration. Implementation on sample_executor.cc
   void InitCronetExecutorApi(
-    ffi.Pointer<ffi.NativeFunction<_typedefC_5>> Cronet_Executor_CreateWith,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_6>>
+    ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_8>>
         Cronet_Executor_SetClientContext,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_7>>
+    ffi.Pointer<ffi.NativeFunction<_typedefC_9>>
         Cronet_Executor_GetClientContext,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_Destroy,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Runnable_Run,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Runnable_Destroy,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
   ) {
     return _InitCronetExecutorApi(
       Cronet_Executor_CreateWith,
@@ -322,6 +327,10 @@ class Cronet_EnginePtr extends ffi.Opaque {}
 
 class Cronet_BufferPtr extends ffi.Opaque {}
 
+class Cronet_UrlResponseInfoPtr extends ffi.Opaque {}
+
+class Cronet_ErrorPtr extends ffi.Opaque {}
+
 class Cronet_ExecutorPtr extends ffi.Opaque {}
 
 class Cronet_RunnablePtr extends ffi.Opaque {}
@@ -329,10 +338,6 @@ class Cronet_RunnablePtr extends ffi.Opaque {}
 class Cronet_UrlRequest extends ffi.Opaque {}
 
 class Cronet_UrlRequestCallbackPtr extends ffi.Opaque {}
-
-class Cronet_UrlResponseInfoPtr extends ffi.Opaque {}
-
-class Cronet_ErrorPtr extends ffi.Opaque {}
 
 typedef _c_InitDartApiDL = ffi.IntPtr Function(
   ffi.Pointer<ffi.Void> data,
@@ -357,11 +362,22 @@ typedef _typedefC_4 = ffi.Void Function(
   ffi.Uint64,
 );
 
+typedef _typedefC_5 = ffi.Int32 Function(
+  ffi.Pointer<Cronet_UrlResponseInfoPtr>,
+);
+
+typedef _typedefC_6 = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<Cronet_ErrorPtr>,
+);
+
 typedef _c_InitCronetApi = ffi.Void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_1>> Cronet_Engine_Shutdown,
   ffi.Pointer<ffi.NativeFunction<_typedefC_2>> Cronet_Engine_Destroy,
   ffi.Pointer<ffi.NativeFunction<_typedefC_3>> Cronet_Buffer_Create,
   ffi.Pointer<ffi.NativeFunction<_typedefC_4>> Cronet_Buffer_InitWithAlloc,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
+      Cronet_UrlResponseInfo_http_status_code_get,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
 );
 
 typedef _dart_InitCronetApi = void Function(
@@ -369,6 +385,9 @@ typedef _dart_InitCronetApi = void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_2>> Cronet_Engine_Destroy,
   ffi.Pointer<ffi.NativeFunction<_typedefC_3>> Cronet_Buffer_Create,
   ffi.Pointer<ffi.NativeFunction<_typedefC_4>> Cronet_Buffer_InitWithAlloc,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
+      Cronet_UrlResponseInfo_http_status_code_get,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
 );
 
 typedef Cronet_Executor_ExecuteFunc = ffi.Void Function(
@@ -376,47 +395,47 @@ typedef Cronet_Executor_ExecuteFunc = ffi.Void Function(
   ffi.Pointer<Cronet_RunnablePtr>,
 );
 
-typedef _typedefC_5 = ffi.Pointer<Cronet_ExecutorPtr> Function(
+typedef _typedefC_7 = ffi.Pointer<Cronet_ExecutorPtr> Function(
   ffi.Pointer<ffi.NativeFunction<Cronet_Executor_ExecuteFunc>>,
-);
-
-typedef _typedefC_6 = ffi.Void Function(
-  ffi.Pointer<Cronet_ExecutorPtr>,
-  ffi.Pointer<ffi.Void>,
-);
-
-typedef _typedefC_7 = ffi.Pointer<ffi.Void> Function(
-  ffi.Pointer<Cronet_ExecutorPtr>,
 );
 
 typedef _typedefC_8 = ffi.Void Function(
   ffi.Pointer<Cronet_ExecutorPtr>,
+  ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_9 = ffi.Void Function(
-  ffi.Pointer<Cronet_RunnablePtr>,
+typedef _typedefC_9 = ffi.Pointer<ffi.Void> Function(
+  ffi.Pointer<Cronet_ExecutorPtr>,
 );
 
 typedef _typedefC_10 = ffi.Void Function(
+  ffi.Pointer<Cronet_ExecutorPtr>,
+);
+
+typedef _typedefC_11 = ffi.Void Function(
+  ffi.Pointer<Cronet_RunnablePtr>,
+);
+
+typedef _typedefC_12 = ffi.Void Function(
   ffi.Pointer<Cronet_RunnablePtr>,
 );
 
 typedef _c_InitCronetExecutorApi = ffi.Void Function(
-  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> Cronet_Executor_CreateWith,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Executor_SetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_GetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_Destroy,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Runnable_Run,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Runnable_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_SetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_GetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
 );
 
 typedef _dart_InitCronetExecutorApi = void Function(
-  ffi.Pointer<ffi.NativeFunction<_typedefC_5>> Cronet_Executor_CreateWith,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Executor_SetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_GetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_Destroy,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Runnable_Run,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Runnable_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_SetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_GetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
 );
 
 typedef _c_RegisterHttpClient = ffi.Void Function(

--- a/lib/src/wrapper/generated_bindings.dart
+++ b/lib/src/wrapper/generated_bindings.dart
@@ -26,6 +26,15 @@ class Wrapper {
           lookup)
       : _lookup = lookup;
 
+  ffi.Pointer<ffi.Int8> versionString() {
+    return _versionString();
+  }
+
+  late final _versionString_ptr =
+      _lookup<ffi.NativeFunction<_c_versionString>>('versionString');
+  late final _dart_versionString _versionString =
+      _versionString_ptr.asFunction<_dart_versionString>();
+
   int InitDartApiDL(
     ffi.Pointer<ffi.Void> data,
   ) {
@@ -341,6 +350,10 @@ class Cronet_RunnablePtr extends ffi.Opaque {}
 class Cronet_UrlRequest extends ffi.Opaque {}
 
 class Cronet_UrlRequestCallbackPtr extends ffi.Opaque {}
+
+typedef _c_versionString = ffi.Pointer<ffi.Int8> Function();
+
+typedef _dart_versionString = ffi.Pointer<ffi.Int8> Function();
 
 typedef _c_InitDartApiDL = ffi.IntPtr Function(
   ffi.Pointer<ffi.Void> data,

--- a/lib/src/wrapper/generated_bindings.dart
+++ b/lib/src/wrapper/generated_bindings.dart
@@ -26,14 +26,14 @@ class Wrapper {
           lookup)
       : _lookup = lookup;
 
-  ffi.Pointer<ffi.Int8> versionString() {
-    return _versionString();
+  ffi.Pointer<ffi.Int8> VersionString() {
+    return _VersionString();
   }
 
-  late final _versionString_ptr =
-      _lookup<ffi.NativeFunction<_c_versionString>>('versionString');
-  late final _dart_versionString _versionString =
-      _versionString_ptr.asFunction<_dart_versionString>();
+  late final _VersionString_ptr =
+      _lookup<ffi.NativeFunction<_c_VersionString>>('VersionString');
+  late final _dart_VersionString _VersionString =
+      _VersionString_ptr.asFunction<_dart_VersionString>();
 
   int InitDartApiDL(
     ffi.Pointer<ffi.Void> data,
@@ -351,9 +351,9 @@ class Cronet_UrlRequest extends ffi.Opaque {}
 
 class Cronet_UrlRequestCallbackPtr extends ffi.Opaque {}
 
-typedef _c_versionString = ffi.Pointer<ffi.Int8> Function();
+typedef _c_VersionString = ffi.Pointer<ffi.Int8> Function();
 
-typedef _dart_versionString = ffi.Pointer<ffi.Int8> Function();
+typedef _dart_VersionString = ffi.Pointer<ffi.Int8> Function();
 
 typedef _c_InitDartApiDL = ffi.IntPtr Function(
   ffi.Pointer<ffi.Void> data,

--- a/lib/src/wrapper/generated_bindings.dart
+++ b/lib/src/wrapper/generated_bindings.dart
@@ -47,6 +47,8 @@ class Wrapper {
     ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
         Cronet_UrlResponseInfo_http_status_code_get,
     ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_7>>
+        Cronet_UrlResponseInfo_http_status_text_get,
   ) {
     return _InitCronetApi(
       Cronet_Engine_Shutdown,
@@ -55,6 +57,7 @@ class Wrapper {
       Cronet_Buffer_InitWithAlloc,
       Cronet_UrlResponseInfo_http_status_code_get,
       Cronet_Error_message_get,
+      Cronet_UrlResponseInfo_http_status_text_get,
     );
   }
 
@@ -65,14 +68,14 @@ class Wrapper {
 
   /// Forward declaration. Implementation on sample_executor.cc
   void InitCronetExecutorApi(
-    ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_8>>
-        Cronet_Executor_SetClientContext,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_CreateWith,
     ffi.Pointer<ffi.NativeFunction<_typedefC_9>>
+        Cronet_Executor_SetClientContext,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_10>>
         Cronet_Executor_GetClientContext,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
-    ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Executor_Destroy,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Run,
+    ffi.Pointer<ffi.NativeFunction<_typedefC_13>> Cronet_Runnable_Destroy,
   ) {
     return _InitCronetExecutorApi(
       Cronet_Executor_CreateWith,
@@ -370,6 +373,10 @@ typedef _typedefC_6 = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<Cronet_ErrorPtr>,
 );
 
+typedef _typedefC_7 = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<Cronet_UrlResponseInfoPtr>,
+);
+
 typedef _c_InitCronetApi = ffi.Void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_1>> Cronet_Engine_Shutdown,
   ffi.Pointer<ffi.NativeFunction<_typedefC_2>> Cronet_Engine_Destroy,
@@ -378,6 +385,8 @@ typedef _c_InitCronetApi = ffi.Void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
       Cronet_UrlResponseInfo_http_status_code_get,
   ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>>
+      Cronet_UrlResponseInfo_http_status_text_get,
 );
 
 typedef _dart_InitCronetApi = void Function(
@@ -388,6 +397,8 @@ typedef _dart_InitCronetApi = void Function(
   ffi.Pointer<ffi.NativeFunction<_typedefC_5>>
       Cronet_UrlResponseInfo_http_status_code_get,
   ffi.Pointer<ffi.NativeFunction<_typedefC_6>> Cronet_Error_message_get,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_7>>
+      Cronet_UrlResponseInfo_http_status_text_get,
 );
 
 typedef Cronet_Executor_ExecuteFunc = ffi.Void Function(
@@ -395,47 +406,49 @@ typedef Cronet_Executor_ExecuteFunc = ffi.Void Function(
   ffi.Pointer<Cronet_RunnablePtr>,
 );
 
-typedef _typedefC_7 = ffi.Pointer<Cronet_ExecutorPtr> Function(
+typedef _typedefC_8 = ffi.Pointer<Cronet_ExecutorPtr> Function(
   ffi.Pointer<ffi.NativeFunction<Cronet_Executor_ExecuteFunc>>,
 );
 
-typedef _typedefC_8 = ffi.Void Function(
+typedef _typedefC_9 = ffi.Void Function(
   ffi.Pointer<Cronet_ExecutorPtr>,
   ffi.Pointer<ffi.Void>,
 );
 
-typedef _typedefC_9 = ffi.Pointer<ffi.Void> Function(
-  ffi.Pointer<Cronet_ExecutorPtr>,
-);
-
-typedef _typedefC_10 = ffi.Void Function(
+typedef _typedefC_10 = ffi.Pointer<ffi.Void> Function(
   ffi.Pointer<Cronet_ExecutorPtr>,
 );
 
 typedef _typedefC_11 = ffi.Void Function(
-  ffi.Pointer<Cronet_RunnablePtr>,
+  ffi.Pointer<Cronet_ExecutorPtr>,
 );
 
 typedef _typedefC_12 = ffi.Void Function(
   ffi.Pointer<Cronet_RunnablePtr>,
 );
 
+typedef _typedefC_13 = ffi.Void Function(
+  ffi.Pointer<Cronet_RunnablePtr>,
+);
+
 typedef _c_InitCronetExecutorApi = ffi.Void Function(
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_SetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_GetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_CreateWith,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_SetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_10>>
+      Cronet_Executor_GetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Executor_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Run,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_13>> Cronet_Runnable_Destroy,
 );
 
 typedef _dart_InitCronetExecutorApi = void Function(
-  ffi.Pointer<ffi.NativeFunction<_typedefC_7>> Cronet_Executor_CreateWith,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_SetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_GetClientContext,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_10>> Cronet_Executor_Destroy,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Runnable_Run,
-  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_8>> Cronet_Executor_CreateWith,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_9>> Cronet_Executor_SetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_10>>
+      Cronet_Executor_GetClientContext,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_11>> Cronet_Executor_Destroy,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_12>> Cronet_Runnable_Run,
+  ffi.Pointer<ffi.NativeFunction<_typedefC_13>> Cronet_Runnable_Destroy,
 );
 
 typedef _c_RegisterHttpClient = ffi.Void Function(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.1
+version: 0.0.1+1
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -17,12 +17,11 @@
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
-#define WRAPPER_MAJOR_V 1
-#define WRAPPER_MINOR_V 0
+#define WRAPPER_VERSION 1
 
-#define WRAPPER_VER STRINGIFY(WRAPPER_MAJOR_V) "." STRINGIFY(WRAPPER_MINOR_V)
+#define WRAPPER_VERSTR STRINGIFY(WRAPPER_VERSION)
 
-const char *VersionString() { return WRAPPER_VER; }
+const char *VersionString() { return WRAPPER_VERSTR; }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -13,6 +13,20 @@
 #include <unordered_map>
 
 ////////////////////////////////////////////////////////////////////////////////
+// Versioning
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x) STRINGIFY_(x)
+
+#define MAJOR_V 1
+#define MINOR_V 0
+
+#define WRAPPER_VER STRINGIFY(MAJOR_V) "." STRINGIFY(MINOR_V)
+
+const char *versionString() { return WRAPPER_VER; }
+
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
 // Globals
 
 std::unordered_map<Cronet_UrlRequestPtr, Dart_Port> requestNativePorts;

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -17,12 +17,12 @@
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
-#define MAJOR_V 1
-#define MINOR_V 0
+#define WRAPPER_MAJOR_V 1
+#define WRAPPER_MINOR_V 0
 
-#define WRAPPER_VER STRINGIFY(MAJOR_V) "." STRINGIFY(MINOR_V)
+#define WRAPPER_VER STRINGIFY(WRAPPER_MAJOR_V) "." STRINGIFY(WRAPPER_MINOR_V)
 
-const char *versionString() { return WRAPPER_VER; }
+const char *VersionString() { return WRAPPER_VER; }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -9,7 +9,9 @@
 #include "../third_party/dart-sdk/dart_tools_api.h"
 #include <iostream>
 #include <stdarg.h>
+#include <string.h>
 #include <unordered_map>
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // Globals
@@ -140,8 +142,11 @@ void OnRedirectReceived(Cronet_UrlRequestCallbackPtr self,
                         Cronet_UrlRequestPtr request,
                         Cronet_UrlResponseInfoPtr info,
                         Cronet_String newLocationUrl) {
+  int len = strlen(newLocationUrl);
+  char *newLoc = (char *)malloc(len + 1);
+  memcpy(newLoc, newLocationUrl, len + 1);
   DispatchCallback("OnRedirectReceived", request,
-                   CallbackArgBuilder(2, newLocationUrl, info));
+                   CallbackArgBuilder(2, newLoc, info));
 }
 
 void OnResponseStarted(Cronet_UrlRequestCallbackPtr self,

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -192,7 +192,6 @@ void OnResponseStarted(Cronet_UrlRequestCallbackPtr self,
   _Cronet_Buffer_InitWithAlloc(buffer, 32 * 1024);
   int statusCode = _Cronet_UrlResponseInfo_http_status_code_get(info);
   // If NOT a 1XX or 2XX status code.
-
   DispatchCallback("OnResponseStarted", request,
                    CallbackArgBuilder(3, statusCode, buffer,
                                       statusText(info, statusCode, 100, 299)));
@@ -222,7 +221,6 @@ void OnFailed(Cronet_UrlRequestCallbackPtr self, Cronet_UrlRequestPtr request,
   int len = strlen(errStr);
   char *dupStr = (char *)malloc(len + 1);
   memcpy(dupStr, errStr, len + 1);
-
   DispatchCallback("OnFailed", request, CallbackArgBuilder(1, dupStr));
 }
 

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -29,7 +29,9 @@ InitCronetApi(Cronet_RESULT (*Cronet_Engine_Shutdown)(Cronet_EnginePtr),
               void (*Cronet_Buffer_InitWithAlloc)(Cronet_BufferPtr, uint64_t),
               int32_t (*Cronet_UrlResponseInfo_http_status_code_get)(
                   const Cronet_UrlResponseInfoPtr),
-              Cronet_String (*Cronet_Error_message_get)(const Cronet_ErrorPtr));
+              Cronet_String (*Cronet_Error_message_get)(const Cronet_ErrorPtr),
+              Cronet_String (*Cronet_UrlResponseInfo_http_status_text_get)(
+                  const Cronet_UrlResponseInfoPtr));
 
 /* Forward declaration. Implementation on sample_executor.cc */
 WRAPPER_EXPORT void InitCronetExecutorApi(

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -21,6 +21,8 @@ extern "C" {
 
 typedef struct SampleExecutor *SampleExecutorPtr;
 
+WRAPPER_EXPORT const char *versionString();
+
 WRAPPER_EXPORT intptr_t InitDartApiDL(void *data);
 WRAPPER_EXPORT void
 InitCronetApi(Cronet_RESULT (*Cronet_Engine_Shutdown)(Cronet_EnginePtr),

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -26,7 +26,10 @@ WRAPPER_EXPORT void
 InitCronetApi(Cronet_RESULT (*Cronet_Engine_Shutdown)(Cronet_EnginePtr),
               void (*Cronet_Engine_Destroy)(Cronet_EnginePtr),
               Cronet_BufferPtr (*Cronet_Buffer_Create)(void),
-              void (*Cronet_Buffer_InitWithAlloc)(Cronet_BufferPtr, uint64_t));
+              void (*Cronet_Buffer_InitWithAlloc)(Cronet_BufferPtr, uint64_t),
+              int32_t (*Cronet_UrlResponseInfo_http_status_code_get)(
+                  const Cronet_UrlResponseInfoPtr),
+              Cronet_String (*Cronet_Error_message_get)(const Cronet_ErrorPtr));
 
 /* Forward declaration. Implementation on sample_executor.cc */
 WRAPPER_EXPORT void InitCronetExecutorApi(

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -21,7 +21,7 @@ extern "C" {
 
 typedef struct SampleExecutor *SampleExecutorPtr;
 
-WRAPPER_EXPORT const char *versionString();
+WRAPPER_EXPORT const char *VersionString();
 
 WRAPPER_EXPORT intptr_t InitDartApiDL(void *data);
 WRAPPER_EXPORT void

--- a/test/http_responses_exceptions_test.dart
+++ b/test/http_responses_exceptions_test.dart
@@ -32,8 +32,8 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>().having(
-                (exception) => exception.message, 'message', 'Not Found')),
+            emitsError(isA<HttpException>()
+                .having((exception) => exception.message, 'message', '404')),
             emitsDone
           ]));
     });
@@ -44,8 +44,8 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>().having(
-                (exception) => exception.message, 'message', 'Unauthorized')),
+            emitsError(isA<HttpException>()
+                .having((exception) => exception.message, 'message', '401')),
             emitsDone
           ]));
     });
@@ -56,10 +56,8 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>().having(
-                (exception) => exception.message,
-                'message',
-                'Service Unavailable')),
+            emitsError(isA<HttpException>()
+                .having((exception) => exception.message, 'message', '503')),
             emitsDone
           ]));
     });

--- a/test/http_responses_exceptions_test.dart
+++ b/test/http_responses_exceptions_test.dart
@@ -32,8 +32,8 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>()
-                .having((exception) => exception.message, 'message', '404')),
+            emitsError(isA<HttpException>().having(
+                (exception) => exception.message, 'message', 'Not Found')),
             emitsDone
           ]));
     });
@@ -44,8 +44,8 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>()
-                .having((exception) => exception.message, 'message', '401')),
+            emitsError(isA<HttpException>().having(
+                (exception) => exception.message, 'message', 'Unauthorized')),
             emitsDone
           ]));
     });
@@ -56,8 +56,10 @@ void main() {
       expect(
           resp,
           emitsInOrder(<Matcher>[
-            emitsError(isA<HttpException>()
-                .having((exception) => exception.message, 'message', '503')),
+            emitsError(isA<HttpException>().having(
+                (exception) => exception.message,
+                'message',
+                'Service Unavailable')),
             emitsDone
           ]));
     });


### PR DESCRIPTION
We shouldn't return pointers that we received as a callback parameter from cronet. In a slower system or while doing bunch of requests togather (e.g. benchmarking), we can accidentally dereference those cronet created pointers after cronet frees them.

UTF8 decoding the newLocation URL string which is received as a callback of onRedirect event causes the following error:
```
Unhandled exception:
FormatException: Unexpected extension byte (at offset .....
```
This PR fixes this issue by dereferencing and getting the raw data from cronet created pointers in the wrapper then sending copied data to the dart side via nativeport.

Also patched crash on parallel request if 404 is received.

**NOTE:** Update Binaries.