### PR TITLE
move to package:args for cli arg parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 0.0.3
+
+* Using `package:args` for handling CLI arguments.
+* Dependency versions increased.
+* Corrected wrong cli command suggestions in case of un-locateable dylibs.
+
 ## 0.0.2
+
 * Added support for MacOS.
 
 ## 0.0.1+1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Using `package:args` for handling CLI arguments.
 * Dependency versions increased.
 * Corrected wrong cli command suggestions in case of un-locateable dylibs.
+* Fixed throughput benchmark's `RangeError` in case of 0 result.
 
 ## 0.0.2
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ dart run benchmark/throughput.dart # For parallel requests benchmark.
 dart run benchmark/run_all.dart # To run all the benchmarks and get reports.
 ```
 
-All the benchmarking scripts take test server url as a cli argument. `throughput.dart` and `run_all.dart` also take `N` where `2^N` is the maximum possible parallel requests and the max duration for each run to complete in seconds.
+Use `-h` to see available cli arguments and usage informations.
 
 To know how to setup local test servers, read [benchmarking guide](benchmark/benchmarking.md).
 

--- a/benchmark/latency.dart
+++ b/benchmark/latency.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io' as io;
 
+import 'package:args/args.dart';
 import 'package:cronet/cronet.dart';
 
 abstract class LatencyBenchmark {
@@ -119,11 +120,24 @@ class CronetLatencyBenchmark extends LatencyBenchmark {
 }
 
 void main(List<String> args) async {
-  // Accepts test url as optional cli parameter.
-  var url = 'https://example.com';
-  if (args.isNotEmpty) {
-    url = args[0];
+  final parser = ArgParser();
+  parser
+    ..addOption('url',
+        abbr: 'u',
+        help: 'The server to ping for running this benchmark.',
+        defaultsTo: 'https://example.com')
+    ..addFlag('help',
+        abbr: 'h', negatable: false, help: 'Print this usage information.');
+  final arguments = parser.parse(args);
+  if (arguments.wasParsed('help')) {
+    print(parser.usage);
+    return;
   }
+  if (arguments.rest.isNotEmpty) {
+    print(parser.usage);
+    throw ArgumentError();
+  }
+  final url = arguments['url'] as String;
   // TODO: https://github.com/google/cronet.dart/issues/11
   await CronetLatencyBenchmark.main(url);
   // Used as an delemeter while parsing output in run_all script.

--- a/benchmark/run_all.dart
+++ b/benchmark/run_all.dart
@@ -39,8 +39,8 @@ void main(List<String> args) async {
         defaultsTo: '10')
     ..addOption('time',
         abbr: 't',
-        help: 'Maximum millisecond the benchmark should wait for each request.',
-        defaultsTo: '1000')
+        help: 'Maximum second(s) the benchmark should wait for each request.',
+        defaultsTo: '1')
     ..addFlag('help',
         abbr: 'h', negatable: false, help: 'Print this usage information.');
   final arguments = parser.parse(args);
@@ -54,8 +54,7 @@ void main(List<String> args) async {
   }
   final url = arguments['url'] as String;
   final throughputPrallelLimit = int.parse(arguments['limit'] as String);
-  final duration =
-      Duration(milliseconds: int.parse(arguments['time'] as String));
+  final duration = Duration(seconds: int.parse(arguments['time'] as String));
 
   print('Latency Test against: $url');
   print('JIT');
@@ -96,7 +95,7 @@ void main(List<String> args) async {
     '-l',
     throughputPrallelLimit.toString(),
     '-t',
-    duration.inMilliseconds.toString()
+    duration.inSeconds.toString()
   ]);
   stderr.addStream(aotThroughputProc.stderr);
   var throughputStdout = '';
@@ -118,7 +117,7 @@ void main(List<String> args) async {
       ' ${jitDartIOLatency.toStringAsFixed(3)} ms   |');
   print('| AOT           | ${aotCronetLatency.toStringAsFixed(3)} ms   |'
       ' ${aotDartIOLatency.toStringAsFixed(3)} ms   |');
-  print('\nThroughput Test Results (Duration: ${duration.inMilliseconds} ms)');
+  print('\nThroughput Test Results (Duration: ${duration.inSeconds}s)');
   print('| Mode          | package:cronet  | dart:io        |');
   print('| :-----------: |:--------------: | :-----------:  |');
   print('| JIT           | ${jitCronetThroughput[1]} out of'

--- a/benchmark/run_all.dart
+++ b/benchmark/run_all.dart
@@ -39,8 +39,8 @@ void main(List<String> args) async {
         defaultsTo: '10')
     ..addOption('time',
         abbr: 't',
-        help: 'Maximum second(s) the benchmark should wait for each request.',
-        defaultsTo: '1')
+        help: 'Maximum millisecond the benchmark should wait for each request.',
+        defaultsTo: '1000')
     ..addFlag('help',
         abbr: 'h', negatable: false, help: 'Print this usage information.');
   final arguments = parser.parse(args);
@@ -54,7 +54,8 @@ void main(List<String> args) async {
   }
   final url = arguments['url'] as String;
   final throughputPrallelLimit = int.parse(arguments['limit'] as String);
-  final duration = Duration(seconds: int.parse(arguments['time'] as String));
+  final duration =
+      Duration(milliseconds: int.parse(arguments['time'] as String));
 
   print('Latency Test against: $url');
   print('JIT');
@@ -95,7 +96,7 @@ void main(List<String> args) async {
     '-l',
     throughputPrallelLimit.toString(),
     '-t',
-    duration.inSeconds.toString()
+    duration.inMilliseconds.toString()
   ]);
   stderr.addStream(aotThroughputProc.stderr);
   var throughputStdout = '';
@@ -117,7 +118,7 @@ void main(List<String> args) async {
       ' ${jitDartIOLatency.toStringAsFixed(3)} ms   |');
   print('| AOT           | ${aotCronetLatency.toStringAsFixed(3)} ms   |'
       ' ${aotDartIOLatency.toStringAsFixed(3)} ms   |');
-  print('\nThroughput Test Results (Duration: ${duration.inSeconds} seconds)');
+  print('\nThroughput Test Results (Duration: ${duration.inMilliseconds} ms)');
   print('| Mode          | package:cronet  | dart:io        |');
   print('| :-----------: |:--------------: | :-----------:  |');
   print('| JIT           | ${jitCronetThroughput[1]} out of'

--- a/benchmark/throughput.dart
+++ b/benchmark/throughput.dart
@@ -165,9 +165,8 @@ void main(List<String> args) async {
         defaultsTo: '10')
     ..addOption('time',
         abbr: 't',
-        help:
-            'Maximum milliseconds the benchmark should wait for each request.',
-        defaultsTo: '1000')
+        help: 'Maximum second(s) the benchmark should wait for each request.',
+        defaultsTo: '1')
     ..addFlag('help',
         abbr: 'h', negatable: false, help: 'Print this usage information.');
   final arguments = parser.parse(args);
@@ -182,8 +181,7 @@ void main(List<String> args) async {
   final url = arguments['url'] as String;
   final spawnThreshold =
       pow(2, int.parse(arguments['limit'] as String)).toInt();
-  final duration =
-      Duration(milliseconds: int.parse(arguments['time'] as String));
+  final duration = Duration(seconds: int.parse(arguments['time'] as String));
   // TODO: https://github.com/google/cronet.dart/issues/11
   await CronetThroughputBenchmark.main(url, spawnThreshold, duration);
   // Used as an delemeter while parsing output in run_all script.

--- a/benchmark/throughput.dart
+++ b/benchmark/throughput.dart
@@ -57,7 +57,7 @@ abstract class ThroughputBenchmark {
 
   Future<List<int>> report() async {
     var maxReturn = 0;
-    var throughput = List<int>.empty();
+    var throughput = [0, 0];
     // Run the benchmark for 1, 2, 4...spawnThreshold.
     for (int currentThreshold = 1;
         currentThreshold <= spawnThreshold;
@@ -165,8 +165,9 @@ void main(List<String> args) async {
         defaultsTo: '10')
     ..addOption('time',
         abbr: 't',
-        help: 'Maximum second(s) the benchmark should wait for each request.',
-        defaultsTo: '1')
+        help:
+            'Maximum milliseconds the benchmark should wait for each request.',
+        defaultsTo: '1000')
     ..addFlag('help',
         abbr: 'h', negatable: false, help: 'Print this usage information.');
   final arguments = parser.parse(args);
@@ -181,7 +182,8 @@ void main(List<String> args) async {
   final url = arguments['url'] as String;
   final spawnThreshold =
       pow(2, int.parse(arguments['limit'] as String)).toInt();
-  final duration = Duration(seconds: int.parse(arguments['time'] as String));
+  final duration =
+      Duration(milliseconds: int.parse(arguments['time'] as String));
   // TODO: https://github.com/google/cronet.dart/issues/11
   await CronetThroughputBenchmark.main(url, spawnThreshold, duration);
   // Used as an delemeter while parsing output in run_all script.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,4 @@
+## Examples
+
+- [Bare Minimum](https://github.com/google/cronet.dart#example)
+- [Simple (Dart CLI)](https://github.com/google/cronet.dart/tree/main/example/)

--- a/lib/src/dylib_handler.dart
+++ b/lib/src/dylib_handler.dart
@@ -133,7 +133,7 @@ DynamicLibrary loadDylib(String name) {
     logger.stdout(
         'To download the binaries, please run the following from the root of'
         ' your project:');
-    logger.stdout('${ansi.yellow}dart run cronet <platform>${ansi.none}');
+    logger.stdout('${ansi.yellow}dart run cronet:setup${ansi.none}');
     logger.stdout('${ansi.green}Valid platforms are:');
     for (final platform in validPlatforms) {
       logger.stdout(platform);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,10 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  ffi: ^1.0.0
+  ffi: ^1.1.2
   path: ^1.8.0
-  cli_util: ^0.3.0
+  args: ^2.1.1
+  cli_util: ^0.3.3
   archive: ^3.1.2
 
 dev_dependencies:

--- a/tool/update_bindings.dart
+++ b/tool/update_bindings.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-void main(List<String> args) async {
+void main() async {
   final root =
       Directory.fromUri(Platform.script).parent.parent.uri.toFilePath();
 


### PR DESCRIPTION
Continuation #8 

- Bumped up the version of every dependency package as much as possible.
- Use `package:args` for CLI argument parsing.
  - - [x] `bin/setup.dart`
  - - [x] `tool/` files. (Tools don't take any CLI arg)
  - - [x] `benchmark/` files.
 - Fixes wrong location issue in `run_all.dart` due to the migration from `benchmarks/` to `benchmark/` (#14 )
 - Fixed wrong cli suggestion in case of un-locateable dylib.
 - Fixes `RangeError (index)` in `benchmark/throughput.dart` in case of 0 result.
 - Added README.md to `example` folder to fetch more pub points.

Closes #12 