### PR TITLE
add HttpClient force close feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.0.4+2
+
+* Added `HttpClient` force close feature.
+
 ## 0.0.4+1
 
-* Fix benchmarking instructions.
+* Fixed benchmarking instructions.
 
 ## 0.0.4
 

--- a/lib/src/http_callback_handler.dart
+++ b/lib/src/http_callback_handler.dart
@@ -48,10 +48,13 @@ class CallbackHandler {
   /// Registers the [NativePort] to the cronet side.
   CallbackHandler(this.executor, this.receivePort);
 
-  /// [Stream] controller for [HttpClientResponse]
+  /// [Stream] for [HttpClientResponse].
   Stream<List<int>> get stream {
     return _controller.stream;
   }
+
+  /// [Stream] controller for [HttpClientResponse].
+  StreamController<List<int>> get controller => _controller;
 
   // Clean up tasks for a request.
   //

--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -76,6 +76,16 @@ class HttpClientRequestImpl implements HttpClientRequest {
   /// Implemented by: http_client.dart.
   final void Function(HttpClientRequest) _clientCleanup;
 
+  /// Pointer associated with [this] request.
+  ///
+  /// This is not a part of public api.
+  Pointer<Cronet_UrlRequest> get requestPtr => _request;
+
+  /// [CallbackHandler] handling this request.
+  ///
+  /// This is not a part of public api.
+  CallbackHandler get callbackHandler => _callbackHandler;
+
   @override
   Encoding encoding;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.4+1
+version: 0.0.4+2
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 


### PR DESCRIPTION
Add force close (optional) parameter to `HttpClient.close()` method along with tests for it.

Original API reference: https://api.dart.dev/stable/2.13.1/dart-io/HttpClient/close.html