### PR TITLE
add 32 bit architecture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+4
+
+* Added support for 32 bit architecture.
+
 ## 0.0.4+3
 
 * Fixed type casting issue between `Uint8List` and `Uint64List` while passing callback arguments from C side to Dart side.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a [GSoC 2021 project](https://summerofcode.withgoogle.com/projects/#4757
 
 ## Supported Platforms
 
-Currently, 64 bit Android and Desktop Platforms (Linux, Windows and MacOS) are supported.
+Currently, Android and Desktop Platforms (Linux, Windows and MacOS) are supported.
 
 ## Requirements
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.4+3
+version: 0.0.4+4
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -125,14 +125,13 @@ Dart_CObject CallbackArgBuilder(int num, ...) {
   Dart_CObject c_request_data;
   va_list valist;
   va_start(valist, num);
-  // Initializing [request_buffer] with 0 will allow us to ensure padding in
-  // the higher 32 bits of 64 bit uint in case of systems with word size of 4
-  // bytes.
-  void *request_buffer = calloc(num, sizeof(uint64_t));
+  void *request_buffer = malloc(sizeof(uint64_t) * num);
   uint64_t *buf = reinterpret_cast<uint64_t *>(request_buffer);
 
+  // uintptr_r will get implicitly casted to uint64_t. So, in a 32 bit machine,
+  // the upper 32 bit of buf[i] will be 0 extended automatically.
   for (int i = 0; i < num; i++) {
-    buf[i] = va_arg(valist, intptr_t);
+    buf[i] = va_arg(valist, uintptr_t);
   }
 
   c_request_data.type = Dart_CObject_kExternalTypedData;

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -128,8 +128,10 @@ Dart_CObject CallbackArgBuilder(int num, ...) {
   void *request_buffer = malloc(sizeof(uint64_t) * num);
   uint64_t *buf = reinterpret_cast<uint64_t *>(request_buffer);
 
-  // uintptr_r will get implicitly casted to uint64_t. So, in a 32 bit machine,
-  // the upper 32 bit of buf[i] will be 0 extended automatically.
+  // uintptr_r will get implicitly casted to uint64_t. So, when the code is
+  // executed in 32 bit mode, the upper 32 bit of buf[i] will be 0 extended
+  // automatically. This is required because, on the Dart side these addresses
+  // are viewed as 64 bit integers.
   for (int i = 0; i < num; i++) {
     buf[i] = va_arg(valist, uintptr_t);
   }

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -9,6 +9,7 @@
 #include "../third_party/dart-sdk/dart_tools_api.h"
 #include <iostream>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unordered_map>
 
@@ -124,11 +125,14 @@ Dart_CObject CallbackArgBuilder(int num, ...) {
   Dart_CObject c_request_data;
   va_list valist;
   va_start(valist, num);
-  void *request_buffer = malloc(sizeof(uint64_t) * num);
+  // Initializing [request_buffer] with 0 will allow us to ensure padding in
+  // the higher 32 bits of 64 bit uint in case of systems with word size of 4
+  // bytes.
+  void *request_buffer = calloc(num, sizeof(uint64_t));
   uint64_t *buf = reinterpret_cast<uint64_t *>(request_buffer);
 
   for (int i = 0; i < num; i++) {
-    buf[i] = va_arg(valist, uint64_t);
+    buf[i] = va_arg(valist, intptr_t);
   }
 
   c_request_data.type = Dart_CObject_kExternalTypedData;


### PR DESCRIPTION
Use an array of `uint64` to store the memory addresses of arguments (of cronet callbacks). On 32 bit systems, we must store the memory address on the lower 32 bits of `uint64` and upper 32 bits should be padded by `0`.

Closes #20 