### PR TITLE
add support for user added headers in http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+5
+
+* Added support for adding user specified headers in `HttpClientRequest`.
+
 ## 0.0.4+4
 
 * Added support for 32 bit architecture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.4+5
+## 0.0.5
 
 * Added support for adding user specified headers in `HttpClientRequest`.
 

--- a/lib/cronet.dart
+++ b/lib/cronet.dart
@@ -7,4 +7,5 @@ export 'src/exceptions.dart';
 export 'src/http_client.dart';
 export 'src/http_client_request.dart' hide HttpClientRequestImpl;
 export 'src/http_client_response.dart' hide HttpClientResponseImpl;
+export 'src/http_headers.dart' hide HttpHeadersImpl;
 export 'src/quic_hint.dart';

--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -243,6 +243,5 @@ class HttpClientRequestImpl implements HttpClientRequest {
   }
 
   @override
-  // TODO: implement headers
   HttpHeaders get headers => _headers;
 }

--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -145,8 +145,8 @@ class HttpClientRequestImpl implements HttpClientRequest {
 
   /// Closes the request for input.
   ///
-  /// Returns [Future] of [HttpClientResponse] which can be listened for server
-  /// response. Throws [UrlRequestError] if request can't be initiated.
+  /// Returns [Future] of [HttpClientResponse] which can be listened to the
+  /// server response. Throws [UrlRequestError] if request can't be initiated.
   @override
   Future<HttpClientResponse> close() {
     return Future(() {

--- a/lib/src/http_headers.dart
+++ b/lib/src/http_headers.dart
@@ -12,8 +12,17 @@ import 'third_party/cronet/generated_bindings.dart';
 /// Headers for HTTP requests.
 ///
 /// In some situations, headers are immutable:
-/// * [HttpClientRequest] have immutable headers from the moment the body is
-/// written to.
+/// [HttpClientRequest] have immutable headers from the moment the body is
+/// written to. In this situation, the mutating methods throw exceptions.
+///
+/// For all operations on HTTP headers the header name is case-insensitive.
+///
+/// To set the value of a header use the `set()` method:
+///
+/// ```dart
+/// request.headers.set('Content-Type',
+///                    'application/json');
+/// ```
 abstract class HttpHeaders {
   /// Sets the header [name] to [value].
   void set(String name, Object value);

--- a/lib/src/http_headers.dart
+++ b/lib/src/http_headers.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'globals.dart';
+import 'third_party/cronet/generated_bindings.dart';
+
+/// Headers for HTTP requests.
+///
+/// In some situations, headers are immutable:
+/// * [HttpClientRequest] have immutable headers from the moment the body is
+/// written to.
+abstract class HttpHeaders {
+  /// Sets the header [name] to [value].
+  void set(String name, Object value);
+}
+
+/// Implementation of [HttpHeaders].
+class HttpHeadersImpl implements HttpHeaders {
+  final Pointer<Cronet_UrlRequestParams> _requestParams;
+  bool isImmutable = false;
+
+  HttpHeadersImpl(this._requestParams);
+
+  @override
+  void set(String name, Object value) {
+    if (isImmutable) {
+      throw StateError('Can not write headers in immutable state.');
+    }
+    final header = cronet.Cronet_HttpHeader_Create();
+    cronet.Cronet_HttpHeader_name_set(header, name.toNativeUtf8().cast());
+    cronet.Cronet_HttpHeader_value_set(
+        header, value.toString().toNativeUtf8().cast());
+    cronet.Cronet_UrlRequestParams_request_headers_add(_requestParams, header);
+    cronet.Cronet_HttpHeader_Destroy(header);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.4+5
+version: 0.0.5
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 name: cronet
-version: 0.0.4+4
+version: 0.0.4+5
 homepage: https://github.com/google/cronet.dart
 description: Experimental Cronet dart bindings.
 

--- a/test/http_headers_test.dart
+++ b/test/http_headers_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:cronet/cronet.dart';
+import 'package:test/test.dart';
+
+const host = 'localhost';
+const sentData = 'Hello, world!';
+
+void main() {
+  group('Header Tests', () {
+    late HttpClient client;
+    late io.HttpServer server;
+    late int port;
+    setUp(() async {
+      client = HttpClient();
+      server = await io.HttpServer.bind(io.InternetAddress.anyIPv6, 0);
+      port = server.port;
+      server.listen((io.HttpRequest request) {
+        request.response.write(request.headers.value('test-header'));
+        request.response.close();
+      });
+    });
+
+    test('Send an arbitrary http header to the server', () async {
+      final request = await client.getUrl(Uri.parse('http://$host:$port/'));
+      request.headers.set('test-header', sentData);
+      final resp = await request.close();
+      final dataStream = resp.transform(utf8.decoder);
+      expect(dataStream, emitsInOrder(<Matcher>[equals(sentData), emitsDone]));
+    });
+
+    test('Mutating headers after request.close throws error', () async {
+      final request = await client.getUrl(Uri.parse('http://$host:$port/'));
+      await request.close();
+      expect(
+          () => request.headers.set('test-header', sentData), throwsStateError);
+    });
+
+    tearDown(() {
+      client.close();
+      server.close();
+    });
+  });
+}


### PR DESCRIPTION
This PR adds support for `HttpHeaders.set` method only for setting arbitrary http headers.

Closes #25 