### PR TITLE
Point to https://pub.dev/packages/cronet_http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ This project has been superseeded by https://pub.dev/packages/cronet_http.
+
 # Experimental Cronet Dart bindings
 
 This package binds to Cronet's [native API](https://chromium.googlesource.com/chromium/src/+/master/components/cronet/native/test_instructions.md) to expose them in Dart.


### PR DESCRIPTION
This repository hasn't received any commits in two years.

We have https://pub.dev/packages/cronet_http now.

After this commit, we intend to archive this repository.